### PR TITLE
Update MapWrapper.js

### DIFF
--- a/src/components/MapWrapper.js
+++ b/src/components/MapWrapper.js
@@ -11,12 +11,12 @@ import XYZ from 'ol/source/XYZ'
 import {transform} from 'ol/proj'
 import {toStringXY} from 'ol/coordinate';
 
-function MapWrapper(props) {
+// set initial state
+const [ map, setMap ] = useState()
+const [ featuresLayer, setFeaturesLayer ] = useState()
+const [ selectedCoord , setSelectedCoord ] = useState()
 
-  // set intial state
-  const [ map, setMap ] = useState()
-  const [ featuresLayer, setFeaturesLayer ] = useState()
-  const [ selectedCoord , setSelectedCoord ] = useState()
+function MapWrapper(props) {
 
   // pull refs
   const mapElement = useRef()


### PR DESCRIPTION
Gets rid of warning:
```
./src/components/MapWrapper.js
  Line 95:5:  React Hook useEffect has missing dependencies: 'featuresLayer' and 'map'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
```